### PR TITLE
Fix `CONTACT` log regexes

### DIFF
--- a/spinel/__init__.py
+++ b/spinel/__init__.py
@@ -15,8 +15,8 @@ from ircrobots.formatting import strip as format_strip
 from .config import Config
 
 RE_NSACCOUNTNAME = re.compile(r"^NickServ (?P<old1>\S+)(?: .(?P<old2>\S+).)? SET:ACCOUNTNAME: (?P<new>\S+)$")
-RE_PSCONTACTADD  = re.compile(r"^ProjectServ \S+( \(\S+\))? PROJECT:CONTACT:ADD: (?P<gc>\S+) ")
-RE_PSCONTACTDEL  = re.compile(r"^ProjectServ \S+( \(\S+\))? PROJECT:CONTACT:DEL: (?P<gc>\S+) ")
+RE_PSCONTACTADD  = re.compile(r"^ProjectServ \S+(?: \(\S+)? PROJECT:CONTACT:ADD: (?P<gc>\S+) ")
+RE_PSCONTACTDEL  = re.compile(r"^ProjectServ \S+(?: \(\S+)? PROJECT:CONTACT:DEL: (?P<gc>\S+) ")
 
 # not in ircstates yet...
 RPL_RSACHALLENGE2      = "740"

--- a/spinel/__init__.py
+++ b/spinel/__init__.py
@@ -15,8 +15,8 @@ from ircrobots.formatting import strip as format_strip
 from .config import Config
 
 RE_NSACCOUNTNAME = re.compile(r"^NickServ (?P<old1>\S+)(?: .(?P<old2>\S+).)? SET:ACCOUNTNAME: (?P<new>\S+)$")
-RE_PSCONTACTADD  = re.compile(r"^ProjectServ \S+ PROJECT:CONTACT:ADD: (?P<gc>\S+) ")
-RE_PSCONTACTDEL  = re.compile(r"^ProjectServ \S+ PROJECT:CONTACT:DEL: (?P<gc>\S+) ")
+RE_PSCONTACTADD  = re.compile(r"^ProjectServ \S+( \(\S+\))? PROJECT:CONTACT:ADD: (?P<gc>\S+) ")
+RE_PSCONTACTDEL  = re.compile(r"^ProjectServ \S+( \(\S+\))? PROJECT:CONTACT:DEL: (?P<gc>\S+) ")
 
 # not in ircstates yet...
 RPL_RSACHALLENGE2      = "740"


### PR DESCRIPTION
Previously `launchd PROJECT:CONTACT:ADD: test to test (primary, private)` would match but `lunchd (launchd) PROJECT:CONTACT:ADD: test to test (primary, private)` would not.